### PR TITLE
add canonical url support

### DIFF
--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -9,7 +9,7 @@ class AboutPage extends Component {
       <div className="about-container">
         <Helmet>
           <title>{`About | ${config.siteTitle}`}</title>
-          <link rel="canonical" href={`https://ai-tester.com/about/`} />
+          <link rel="canonical" href={`${config.siteUrl}/about/`} />
         </Helmet>
         <About />
       </div>

--- a/src/pages/about.jsx
+++ b/src/pages/about.jsx
@@ -7,7 +7,10 @@ class AboutPage extends Component {
   render() {
     return (
       <div className="about-container">
-        <Helmet title={`About | ${config.siteTitle}`} />
+        <Helmet>
+          <title>{`About | ${config.siteTitle}`}</title>
+          <link rel="canonical" href={`https://ai-tester.com/about/`} />
+        </Helmet>
         <About />
       </div>
     );

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -11,7 +11,7 @@ class Index extends React.Component {
       <div className="index-container">
         <Helmet>
           <title>{config.siteTitle}</title>
-          <link rel="canonical" href={`https://ai-tester.com/`} />
+          <link rel="canonical" href={`${config.siteUrl}`} />
         </Helmet>
         <SEO postEdges={postEdges} />
         <PostListing postEdges={postEdges} />

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -9,7 +9,10 @@ class Index extends React.Component {
     const postEdges = this.props.data.allMarkdownRemark.edges;
     return (
       <div className="index-container">
-        <Helmet title={config.siteTitle} />
+        <Helmet>
+          <title>{config.siteTitle}</title>
+          <link rel="canonical" href={`https://ai-tester.com/`} />
+        </Helmet>
         <SEO postEdges={postEdges} />
         <PostListing postEdges={postEdges} />
       </div>

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -56,6 +56,7 @@ export default class PostTemplate extends React.Component {
       <div className="post-page md-grid md-grid--no-spacing">
         <Helmet>
           <title>{`${post.title} | ${config.siteTitle}`}</title>
+          <link rel="canonical" href={`https://ai-tester.com${post.id}`} />
         </Helmet>
         <SEO postPath={slug} postNode={postNode} postSEO />
         <PostCover postNode={postNode} mobile={mobile} />

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -56,7 +56,7 @@ export default class PostTemplate extends React.Component {
       <div className="post-page md-grid md-grid--no-spacing">
         <Helmet>
           <title>{`${post.title} | ${config.siteTitle}`}</title>
-          <link rel="canonical" href={`https://ai-tester.com${post.id}`} />
+          <link rel="canonical" href={`${config.siteUrl}${post.id}`} />
         </Helmet>
         <SEO postPath={slug} postNode={postNode} postSEO />
         <PostCover postNode={postNode} mobile={mobile} />

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -11,7 +11,7 @@ export default class TagTemplate extends React.Component {
       <div className="tag-container">
         <Helmet>
           <title>{`Posts tagged as "${tag}" | ${config.siteTitle}`}</title>
-          <link rel="canonical" href={`https://ai-tester.com/tags/${tag}`} />
+          <link rel="canonical" href={`${config.siteUrl}/tags/${tag}`} />
         </Helmet>
         <PostListing postEdges={postEdges} />
       </div>
@@ -19,7 +19,7 @@ export default class TagTemplate extends React.Component {
   }
 }
 
-/* eslint no-undef: "off"*/
+/* eslint no-undef: "off" */
 export const pageQuery = graphql`
   query TagPage($tag: String) {
     allMarkdownRemark(

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -9,7 +9,10 @@ export default class TagTemplate extends React.Component {
     const postEdges = this.props.data.allMarkdownRemark.edges;
     return (
       <div className="tag-container">
-        <Helmet title={`Posts tagged as "${tag}" | ${config.siteTitle}`} />
+        <Helmet>
+          <title>{`Posts tagged as "${tag}" | ${config.siteTitle}`}</title>
+          <link rel="canonical" href={`https://ai-tester.com/tags/${tag}`} />
+        </Helmet>
         <PostListing postEdges={postEdges} />
       </div>
     );


### PR DESCRIPTION
Some simple fix to add canonical url generate in the header metadata.

https://support.google.com/webmasters/answer/139066