### PR TITLE
add canonical url for categories pages

### DIFF
--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -9,9 +9,10 @@ export default class CategoryTemplate extends React.Component {
     const postEdges = this.props.data.allMarkdownRemark.edges;
     return (
       <div className="category-container">
-        <Helmet
-          title={`Posts in category "${category}" | ${config.siteTitle}`}
-        />
+        <Helmet>
+          <title>{`Posts in category "${category}" | ${config.siteTitle}`}</title>
+          <link rel="canonical" href={`${config.siteUrl}/categories/${category}`} />
+        </Helmet>
         <PostListing postEdges={postEdges} />
       </div>
     );


### PR DESCRIPTION
Sorry, missing the canonical url for categories pages.