### PR TITLE
add option for fixed footer

### DIFF
--- a/data/SiteConfig.js
+++ b/data/SiteConfig.js
@@ -5,6 +5,7 @@ module.exports = {
   siteLogo: "/logos/logo-1024.png", // Logo used for SEO and manifest.
   siteUrl: "https://vagr9k.github.io", // Domain of your website without pathPrefix.
   pathPrefix: "/gatsby-material-starter", // Prefixes all links. For cases when deployed to example.github.io/gatsby-material-starter/.
+  fixedFooter: false, // Whether the footer component is fixed, i.e. always visible
   siteDescription: "A GatsbyJS stater with Material design in mind.", // Website description used for RSS feeds/meta description tag.
   siteRss: "/rss.xml", // Path to the RSS file.
   siteFBAppID: "1825356251115265", // FB Application ID for using app insights

--- a/src/components/Footer/Footer.jsx
+++ b/src/components/Footer/Footer.jsx
@@ -10,11 +10,12 @@ class Footer extends Component {
     const url = config.siteRss;
     const { userLinks } = this.props;
     const copyright = config.copyright;
+    const fixedFooter = config.fixedFooter;
     if (!copyright) {
       return null;
     }
     return (
-      <footer className="footer">
+      <footer className={fixedFooter ? "footer footer-fixed" : "footer"}>
         {userLinks ? <UserLinks config={config} labeled /> : null}
         <div className="notice-container">
           <div className="copyright">

--- a/src/components/Footer/Footer.scss
+++ b/src/components/Footer/Footer.scss
@@ -51,3 +51,11 @@
         }
     }
 }
+
+.footer-fixed {
+    position: fixed;
+    left: 0;
+    bottom: 0;
+    right: 0;
+    z-index: 15;
+}


### PR DESCRIPTION
Default false so doesn't change anything, but adds the option to set the footer to be fixed (always visible). Most useful for customizing the footer to have more significant features (e.g. music player, etc.), or if you just have a really long page but want the footer to show up.

On the "really long" note, I'm also looking into pagination with Gatsby, and ran across this - https://github.com/pixelstew/gatsby-paginate

I'm thinking of trying to integrate it with this starter, but I'm not sure if (a) somebody is already doing something similar, or (b) such a change is beyond the scope of this starter, i.e. you don't want pagination. If such a change would potentially be welcome though please let me know - thanks!