### PR TITLE
Add gatsby build to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ Install this starter (assuming [Gatsby](https://github.com/gatsbyjs/gatsby/) is 
 
 ```sh
 gatsby new YourProjectName https://github.com/Vagr9K/gatsby-material-starter
+gatsby build
 npm run serve
 ```
 


### PR DESCRIPTION
`npm run serve` didn't work until `gatsby build` had been run first