### PR TITLE
Refactor for SEO Component

### DIFF
--- a/src/components/SEO/index.jsx
+++ b/src/components/SEO/index.jsx
@@ -1,71 +1,10 @@
 import React, { Component } from "react";
 import Helmet from "react-helmet";
-import urljoin from "url-join";
 import config from "../../../data/SiteConfig";
 
 class SEO extends Component {
   render() {
-    const { postNode, postPath, postSEO } = this.props;
-    let title;
-    let description;
-    let image;
-    let postURL;
-    if (postSEO) {
-      const postMeta = postNode.frontmatter;
-      ({ title } = postMeta);
-      description = postMeta.description
-        ? postMeta.description
-        : postNode.excerpt;
-      image = postMeta.cover;
-      postURL = urljoin(config.siteUrl, config.pathPrefix, postPath);
-    } else {
-      title = config.siteTitle;
-      description = config.siteDescription;
-      image = config.siteLogo;
-    }
-    image = urljoin(config.siteUrl, config.pathPrefix, image);
-    const blogURL = urljoin(config.siteUrl, config.pathPrefix);
-    const schemaOrgJSONLD = [
-      {
-        "@context": "http://schema.org",
-        "@type": "WebSite",
-        url: blogURL,
-        name: title,
-        alternateName: config.siteTitleAlt ? config.siteTitleAlt : ""
-      }
-    ];
-    if (postSEO) {
-      schemaOrgJSONLD.push([
-        {
-          "@context": "http://schema.org",
-          "@type": "BreadcrumbList",
-          itemListElement: [
-            {
-              "@type": "ListItem",
-              position: 1,
-              item: {
-                "@id": postURL,
-                name: title,
-                image
-              }
-            }
-          ]
-        },
-        {
-          "@context": "http://schema.org",
-          "@type": "BlogPosting",
-          url: blogURL,
-          name: title,
-          alternateName: config.siteTitleAlt ? config.siteTitleAlt : "",
-          headline: title,
-          image: {
-            "@type": "ImageObject",
-            url: image
-          },
-          description
-        }
-      ]);
-    }
+    const {title, description, image, url, type, schemaOrgJSONLD} = this.props;
     return (
       <Helmet>
         {/* General tags */}
@@ -78,8 +17,8 @@ class SEO extends Component {
         </script>
 
         {/* OpenGraph tags */}
-        <meta property="og:url" content={postSEO ? postURL : blogURL} />
-        {postSEO ? <meta property="og:type" content="article" /> : null}
+        <meta property="og:url" content={url} />
+        <meta property="og:type" content={type} />
         <meta property="og:title" content={title} />
         <meta property="og:description" content={description} />
         <meta property="og:image" content={image} />
@@ -100,6 +39,13 @@ class SEO extends Component {
       </Helmet>
     );
   }
+}
+
+SEO.defaultProps = {
+  title: config.siteTitle,
+  description: config.siteDescription,
+  image: config.siteLogo,
+  url: config.siteUrl + config.pathPrefix
 }
 
 export default SEO;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -5,6 +5,7 @@ import Layout from "../layout";
 import PostListing from "../components/PostListing";
 import SEO from "../components/SEO";
 import config from "../../data/SiteConfig";
+import {transformConfig} from "../utils/jsonld"
 
 class Index extends React.Component {
   render() {
@@ -16,7 +17,11 @@ class Index extends React.Component {
             <title>{config.siteTitle}</title>
             <link rel="canonical" href={`${config.siteUrl}`} />
           </Helmet>
-          <SEO postEdges={postEdges} />
+          <SEO
+            schemaOrgJSONLD={transformConfig(config)}
+            postEdges={postEdges}
+            type="website"
+          />
           <PostListing postEdges={postEdges} />
         </div>
       </Layout>

--- a/src/templates/post.jsx
+++ b/src/templates/post.jsx
@@ -3,6 +3,7 @@ import Helmet from "react-helmet";
 import { graphql } from "gatsby";
 import Card from "react-md/lib/Cards";
 import CardText from "react-md/lib/Cards/CardText";
+import urljoin from "url-join";
 import Layout from "../layout";
 import UserInfo from "../components/UserInfo";
 import Disqus from "../components/Disqus";
@@ -15,6 +16,8 @@ import SEO from "../components/SEO";
 import config from "../../data/SiteConfig";
 import "./b16-tomorrow-dark.css";
 import "./post.scss";
+
+import {transformConfig, transformPost} from '../utils/jsonld';
 
 export default class PostTemplate extends React.Component {
   constructor(props) {
@@ -54,7 +57,11 @@ export default class PostTemplate extends React.Component {
     if (!post.category_id) {
       post.category_id = config.postDefaultCategoryID;
     }
-
+    const description = post.description ? post.description : postNode.excerpt
+    const blogURL = urljoin(config.siteUrl, config.pathPrefix)
+    const postURL = urljoin(config.siteUrl, config.pathPrefix, slug)
+    const schemaOrgJSONLD = transformConfig(config);
+    schemaOrgJSONLD.push(transformPost(postURL, post, description, blogURL, config.siteTitleAlt))
     const coverHeight = mobile ? 180 : 350;
     return (
       <Layout location={this.props.location}>
@@ -63,7 +70,14 @@ export default class PostTemplate extends React.Component {
             <title>{`${post.title} | ${config.siteTitle}`}</title>
             <link rel="canonical" href={`${config.siteUrl}${post.id}`} />
           </Helmet>
-          <SEO postPath={slug} postNode={postNode} postSEO />
+          <SEO
+            url={postURL}
+            title={post.title}
+            description={description}
+            image={post.cover}
+            schemaOrgJSONLD={schemaOrgJSONLD}
+            type="article"
+          />
           <PostCover
             postNode={postNode}
             coverHeight={coverHeight}

--- a/src/utils/jsonld.js
+++ b/src/utils/jsonld.js
@@ -1,0 +1,46 @@
+export const transformConfig = (config) => ([
+  {
+    "@context": "http://schema.org",
+    "@type": "WebSite",
+    url: config.siteUrl + config.pathPrefix,
+    name: config.siteTitle,
+    alternateName: config.siteTitleAlt ? config.siteTitleAlt : ""
+  }
+])
+
+export const transformPost = (postURL, postMeta, description, blogURL, siteTitleAlt="") => {
+  const { title } = postMeta;
+  const image = postMeta.cover;
+  return [
+    {
+      "@context": "http://schema.org",
+      "@type": "BreadcrumbList",
+      itemListElement: [
+        {
+          "@type": "ListItem",
+          position: 1,
+          item: {
+            "@id": postURL,
+            name: title,
+            image
+          }
+        }
+      ]
+    },
+    {
+      "@context": "http://schema.org",
+      "@type": "BlogPosting",
+      url: blogURL,
+      name: title,
+      alternateName: siteTitleAlt,
+      headline: title,
+      image: {
+        "@type": "ImageObject",
+        url: image
+      },
+      description
+    }
+  ]
+}
+
+export default transformConfig;


### PR DESCRIPTION
fixes #54 
Notes, this refactor allows to create new pages and metadata for each, also cleans the ugly if into the SEO component, default props from siteConfig, is a better aproach than the other so, the required props is reduced to 3