### PR TITLE
Fix prevNode being incorrect for the second post node

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -20,7 +20,7 @@ function addSiblingNodes(createNodeField) {
   );
   for (let i = 0; i < postNodes.length; i += 1) {
     const nextID = i + 1 < postNodes.length ? i + 1 : 0;
-    const prevID = i - 1 > 0 ? i - 1 : postNodes.length - 1;
+    const prevID = i - 1 >= 0 ? i - 1 : postNodes.length - 1;
     const currNode = postNodes[i];
     const nextNode = postNodes[nextID];
     const prevNode = postNodes[prevID];


### PR DESCRIPTION
Fixes issue #61 

We should check `i - 1` is greater than _or_ equal to 0 so that when `i` is `1` `prevID` becomes `0` (the bug had `prevID` becoming `postNodes.length - 1`